### PR TITLE
Update InvokeTwitterAPIs.psm1

### DIFF
--- a/InvokeTwitterAPIs.psm1
+++ b/InvokeTwitterAPIs.psm1
@@ -67,7 +67,7 @@ function Get-OAuth {
 	        ## Base64 allows for an '=' but Twitter does not.  If this is found, replace it with some alphanumeric character
 	        $OauthNonce = [System.Convert]::ToBase64String(([System.Text.Encoding]::ASCII.GetBytes("$([System.DateTime]::Now.Ticks.ToString())12345"))).Replace('=', 'g')
     	    ## Find the total seconds since 1/1/1970 (epoch time)
-		    $EpochTimeNow = [System.DateTime]::UtcNow - [System.DateTime]::ParseExact("01/01/1970", "dd/MM/yyyy", $null)
+		    $EpochTimeNow = [System.DateTime]::UtcNow - [System.DateTime]::ParseExact("01/01/1970", "dd'/'MM'/'yyyy", $null)
 		    $OauthTimestamp = [System.Convert]::ToInt64($EpochTimeNow.TotalSeconds).ToString();
         	## Build the signature
 			$SignatureBase = "$([System.Uri]::EscapeDataString($AuthorizationParams.HttpEndPoint))&"


### PR DESCRIPTION
The change is need it because of the folowing error "Exception calling "ParseExact" with "3" argument(s): "String was not recognized as a valid DateTime."  

For some cultures the format has to be set like "dd'/'MM'/'yyyy" if not .net will intrepret as the default date separator. 
Ex: for ro-RO the DateTime.Now.ToString("dd/MM/YYY") will result in 01.01.1970  ParseExact will fail for 01/01/1970
